### PR TITLE
Better error handling if user closes modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Added `tid` and `message` fields to gateway callback so that user gets a better error message if they close the modal before completing Affirm checkout.
+
 ## [2.0.2] - 2020-04-06
 
 ### Fixed

--- a/react/components/AffirmModal.tsx
+++ b/react/components/AffirmModal.tsx
@@ -67,10 +67,13 @@ class AffirmModal extends Component<AffirmAuthenticationProps> {
 
   public async respondTransaction(status: boolean) {
     if (!status) {
-      await fetch(`${this.props.orderData.callbackUrl}?status=denied`, {
-        method: 'post',
-        mode: 'no-cors',
-      })
+      await fetch(
+        `${this.props.orderData.callbackUrl}?tid=${this.props.orderData.transactionId}&message=Modal failed or was closed by user&status=denied`,
+        {
+          method: 'post',
+          mode: 'no-cors',
+        }
+      )
     }
     $(window).trigger('transactionValidation.vtex', [status])
   }


### PR DESCRIPTION
Added `tid` and `message` fields to gateway callback so that user gets a better error message if they close the modal before completing Affirm checkout.