### PR TITLE
Wrike 495008921: Send discount info to Affirm Checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `discounts` object to Affirm Checkout call
+
 ## [2.0.4] - 2020-04-07
 
 ### Fixed

--- a/react/components/AffirmModal.tsx
+++ b/react/components/AffirmModal.tsx
@@ -122,6 +122,19 @@ class AffirmModal extends Component<AffirmAuthenticationProps> {
         unit_price: Math.round(item.price * 100),
         qty: item.quantity,
       }))
+      let discountTotal = 0
+      orderData.miniCart.items.forEach((item: any) => {
+        discountTotal += item.discount * -1
+      })
+      const discountsObject =
+        discountTotal > 0
+          ? {
+              DISCOUNT: {
+                discount_amount: Math.round(discountTotal * 100),
+                discount_display_name: 'Discount',
+              },
+            }
+          : {}
       window.affirm.checkout({
         merchant: {
           exchange_lease_enabled: enableKatapult,
@@ -169,6 +182,7 @@ class AffirmModal extends Component<AffirmAuthenticationProps> {
           mode: 'modal',
         },
         order_id: orderData.orderId,
+        discounts: discountsObject,
         shipping_amount: Math.round(miniCart.shippingValue * 100),
         tax_amount: Math.round(miniCart.taxValue * 100),
         total: Math.round(orderData.value * 100),

--- a/react/graphql/OrderData.graphql
+++ b/react/graphql/OrderData.graphql
@@ -32,6 +32,7 @@ query OrderData($qs: String) {
         name
         price
         quantity
+        discount
       }
       shippingValue
       taxValue


### PR DESCRIPTION
If discounts are present in the cart, Affirm app now provides a "discounts" object to Affirm Checkout that looks like this:

`"discounts": {
  "DISCOUNT": {
    "discount_amount": 1000,
    "discount_display_name": "Discount"
  }
}`

New version linked here: https://affirmtest--motorolasandbox.myvtex.com/