### PR TITLE
Catch GraphQL errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- add catch statement for inbound request mutation in case of timeouts or other errors
+
 ## [2.1.0] - 2020-04-22
 
 ### Changed

--- a/react/components/AffirmModal.tsx
+++ b/react/components/AffirmModal.tsx
@@ -190,7 +190,7 @@ class AffirmModal extends Component<AffirmAuthenticationProps> {
         // eslint-disable-next-line prettier/prettier
         onSuccess: async function (a: any) {
           vtex.checkout.MessageUtils.showPaymentMessage()
-          const response = await orderUpdateMutation({
+          orderUpdateMutation({
             variables: {
               url: orderData.inboundRequestsUrl
                 .replace('https', 'http')
@@ -201,11 +201,16 @@ class AffirmModal extends Component<AffirmAuthenticationProps> {
               orderTotal: Math.round(orderData.value * 100),
             },
           })
-          if (response.data && response.data.orderUpdate) {
-            await self.respondTransaction(true)
-          } else {
-            await self.respondTransaction(false)
-          }
+            .then((response) => {
+              if (response.data?.orderUpdate) {
+                self.respondTransaction(true)
+              } else {
+                self.respondTransaction(false)
+              }
+            })
+            .catch(() => {
+              $(window).trigger('transactionValidation.vtex', [false])
+            })
         },
       })
 


### PR DESCRIPTION
While testing Affirm I got a 504 gateway timeout from the inbound request GraphQL mutation that the app performs after the shopper completes the Affirm modal. This PR adds a catch statement to handle errors like this.

New version tested and linked here: https://affirm--motorolasandbox.myvtex.com/