### PR TITLE
Add platform metadata, improve clarity of settings and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Add platform metadata to Affirm checkout object
+- Reorder app settings and adjust descriptions for improved clarity
+- Update docs to reflect settings changes
+
 ## [2.1.4] - 2020-09-23
 
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-📢 Use this project, [contribute](https://github.com/vtex-apps/affirm-components) to it or open issues to help evolve it using [Store Discussion](https://github.com/vtex-apps/store-discussion).
+📢 Use this project, [contribute](https://github.com/vtex-apps/affirm-payment) to it or open issues to help evolve it using [Store Discussion](https://github.com/vtex-apps/store-discussion).
 
 # Affirm Payment
 
@@ -6,19 +6,19 @@ This is a payment authorization app for the Affirm payment method (financing wit
 
 ## Configuration
 
-1. Enable Affirm as a payment method in your store admin. In the Gateway Affiliation, enter your Affirm public API key as the `Application Key` and your Affirm private API key as the `Application Token`.
-2. Install this app in your account by running `vtex install vtex.affirm-payment`.
-3. Configure the app settings by clicking "Apps" in your admin sidebar and then selecting "Affirm Payment".
+1. Enable Affirm as a payment method in your store admin. In the Gateway Affiliation, enter your Affirm public API key as the `Application Key` and your Affirm private API key as the `Application Token`. For initial testing, set the Test/Production toggle to `Test` and use sandbox keys.
+2. [Install this app](https://vtex.io/docs/recipes/development/installing-an-app/) in your account by running `vtex install vtex.affirm-payment`.
+3. Configure the app settings by clicking `Apps > My Apps` in your account's admin sidebar and then selecting "Affirm Payment".
 
 The available settings are:
 
-- `Production Mode`: Initial testing should be performed with this box unchecked. When you are ready to process live transactions, check the box and save.
 - `Enable Katapult`: Katapult is a newer Affirm feature that offers a leasing option to shoppers who do not qualify for the normal Affirm financing. Please ask your Affirm contact to enable the feature on your Affirm account before enabling this app setting.
 - `Company Name`: If you have multiple sites operating under a single Affirm account, you can override the external company/brand name that the customer sees. This affects all references to your company name in the Affirm UI. Leave blank to use your default company name stored in your Affirm account.
-- `Public API Key`: The public API key provided to you by Affirm.
+- `Public API Key for promotional components`: The public API key provided to you by Affirm.
+- `Production Mode for promotional components`: Determines if the components from the [Affirm Components](https://github.com/vtex-apps/affirm-components) app run in Production or Sandbox mode.
 - `Interval to use for the following three settings`: Determines the unit of time used by the following settings.
 - `Delay to auto-settle`: Number of minutes/hours/days before authorized Affirm payments are automatically settled.
 - `Delay to auto-settle after anti-fraud`: Number of minutes/hours/days before authorized Affirm payments are automatically settled after merchant's antifraud approval.
 - `Delay to cancel`: Number of minutes/hours/days before Affirm payments are automatically canceled.
-- `Katapult public token`: The public API token for your Katapult account.
-- `Katapult private token`: The private API token for your Katapult account.
+- `Katapult public token`: The public API token for your Katapult account. This is only needed if Katapult is enabled.
+- `Katapult private token`: The private API token for your Katapult account. This is only needed if Katapult is enabled.

--- a/manifest.json
+++ b/manifest.json
@@ -5,9 +5,7 @@
   "title": "Affirm Payment",
   "description": "An implentation of Affirm payment method",
   "categories": [],
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "builders": {
     "react": "2.x",
     "node": "4.x",
@@ -28,12 +26,6 @@
     "title": "Affirm Integration",
     "type": "object",
     "properties": {
-      "isLive": {
-        "title": "Production Mode (Store Components only)",
-        "description": "Set to true for production mode, false for sandbox mode. Does NOT affect Affirm checkout - use payment gateway setting to change checkout mode.",
-        "type": "boolean",
-        "default": false
-      },
       "enableKatapult": {
         "title": "Enable Katapult",
         "description": "Set to true if you wish to enable Katapult leasing option",
@@ -47,19 +39,21 @@
         "default": ""
       },
       "publicApiKey": {
-        "title": "Public API Key",
+        "title": "Public API Key for promotional components",
         "description": "The public API key for your Affirm account",
         "type": "string",
         "default": ""
       },
+      "isLive": {
+        "title": "Production Mode for promotional components",
+        "description": "Set to true for production mode, false for sandbox mode. Does NOT affect Affirm checkout - use payment gateway setting to change checkout mode.",
+        "type": "boolean",
+        "default": false
+      },
       "delayInterval": {
         "title": "Interval to use for the following three settings",
         "type": "string",
-        "enum": [
-          "Minutes",
-          "Hours",
-          "Days"
-        ],
+        "enum": ["Minutes", "Hours", "Days"],
         "default": "Days"
       },
       "delayToAutoSettle": {
@@ -81,13 +75,13 @@
         "default": 30
       },
       "katapultPublicToken": {
-        "title": "Katapult public token",
+        "title": "Katapult public token (optional)",
         "description": "The public API token for your Katapult account",
         "type": "string",
         "default": ""
       },
       "katapultPrivateToken": {
-        "title": "Katapult private token",
+        "title": "Katapult private token (optional)",
         "description": "The private API token for your Katapult account",
         "type": "string",
         "default": ""

--- a/react/components/AffirmModal.tsx
+++ b/react/components/AffirmModal.tsx
@@ -31,6 +31,8 @@ interface OrderData {
 declare const vtex: any
 declare const $: any
 
+const version = process.env.VTEX_APP_VERSION
+
 class AffirmModal extends Component<AffirmAuthenticationProps> {
   public state = {
     scriptLoaded: false,
@@ -174,6 +176,9 @@ class AffirmModal extends Component<AffirmAuthenticationProps> {
       metadata: {
         shipping_type: '',
         mode: 'modal',
+        platform_type: 'VTEX',
+        platform_version: version,
+        platform_affirm: 'Affirm_2.0',
       },
       order_id: orderData.orderId,
       discounts: discountsObject,


### PR DESCRIPTION
This PR adds "platform metadata" to the Affirm checkout JS object, as recommended here: https://docs.affirm.com/affirm-developers/docs/platform-metadata

This will give Affirm awareness that a given transaction was initiated from a site running on the VTEX platform, which will assist in debugging as well as increasing awareness of our integration app.

This has been published as a beta version and is currently installed in sandboxusdev master for testing.