### PR TITLE
[AFFIRM-17] Raise timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Raised app timeout from 10 to 20 seconds
+
 ## [2.2.0] - 2022-03-22
 
 ### Added

--- a/node/package.json
+++ b/node/package.json
@@ -12,7 +12,7 @@
     "typescript": "3.9.7"
   },
   "devDependencies": {
-    "@vtex/api": "6.45.6",
+    "@vtex/api": "6.45.10",
     "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.122.0/public/@types/vtex.store",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.2/public/@types/vtex.styleguide"
   }

--- a/node/service.json
+++ b/node/service.json
@@ -1,7 +1,7 @@
 {
   "memory": 128,
   "ttl": 60,
-  "timeout": 10,
+  "timeout": 20,
   "minReplicas": 2,
   "maxReplicas": 4,
   "workers": 1

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -129,10 +129,10 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@vtex/api@6.45.6":
-  version "6.45.6"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.6.tgz#e5f08476d7c76f26baa1c040666d1364bdd6bc35"
-  integrity sha512-9pDiUxcUzq8RZa9yBex4C8dcAHXBRGAZokvHJ6sykrojq6mJxs+rUTE28TPeeQxwvvKsvrdpsfCUAYQ+UDz+zA==
+"@vtex/api@6.45.10":
+  version "6.45.10"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.10.tgz#d338d05341e176593124fa171ea5710eee802e61"
+  integrity sha512-1OllEdBosqGbyGSvQtJzplmOISj2jalpgTDhRWlzhCdkGYbAg0Sm4doudKfZdvizu/6D1Dz4Uy2YncT6M3Vzng==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
Motorola has reported that `vtex.affirm-payment` is throwing a timeout error during GraphQL execution, presumably when executing the `orderData` query. This causes the Affirm modal to fail to appear during checkout, preventing the sale. This PR raises the app's timeout from 10 seconds to 20 seconds in an effort to solve this problem. Further improvement may be needed if the app continues to time out.

Linked here to verify build success: https://b2bsuite--sandboxusdev.myvtex.com