### PR TITLE
[AFFIRM-26] In subaccount scenario, get order data from main acct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,30 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- In subaccount scenario, query order data from main account
+
 ## [2.2.4] - 2022-11-04
 
 ### Changed
+
 - Fix security issues reported by Dependabot alerts (critical, high, and low)
 
 ### Changed
+
 - Reusable workflow migrated to version 2
 
 ## [2.2.3] - 2022-08-09
 
 ### Fixed
+
 - Adjust placement of query context
 
 ## [2.2.2] - 2022-08-02
 
 ### Added
+
 - Added security to app services
 
 ## [2.2.1] - 2022-04-15

--- a/manifest.json
+++ b/manifest.json
@@ -5,9 +5,7 @@
   "title": "Affirm Payment",
   "description": "An implentation of Affirm payment method",
   "categories": [],
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "builders": {
     "react": "2.x",
     "node": "6.x",
@@ -55,11 +53,7 @@
       "delayInterval": {
         "title": "Interval to use for the following three settings",
         "type": "string",
-        "enum": [
-          "Minutes",
-          "Hours",
-          "Days"
-        ],
+        "enum": ["Minutes", "Hours", "Days"],
         "default": "Days"
       },
       "delayToAutoSettle": {
@@ -96,6 +90,9 @@
   },
   "policies": [
     {
+      "name": "Get_Account_By_Identifier"
+    },
+    {
       "name": "outbound-access",
       "attrs": {
         "host": "{{account}}.vtexcommercestable.com.br",
@@ -112,7 +109,7 @@
     {
       "name": "outbound-access",
       "attrs": {
-        "host": "{{workspace}}--{{account}}.{{process.env.VTEX_PUBLIC_ENDPOINT}}",
+        "host": "*",
         "path": "/affirm/*"
       }
     }

--- a/node/clients/payments.ts
+++ b/node/clients/payments.ts
@@ -2,13 +2,22 @@ import { ExternalClient, InstanceOptions, IOContext } from '@vtex/api'
 
 export default class AffirmDataSource extends ExternalClient {
   constructor(context: IOContext, options?: InstanceOptions) {
-    super(
-      `http://${context.workspace}--${context.account}.${process.env.VTEX_PUBLIC_ENDPOINT}/affirm/payment-provider/`,
-      context,
-      options
-    )
+    super(``, context, options)
   }
 
-  public getPaymentRequest = (qs: string) =>
-    this.http.get(`payments/${qs}/request`, { metric: 'payment-request' })
+  public getPaymentRequest = (
+    qs: string,
+    account: string = this.context.account,
+    workspace: string = this.context.workspace
+  ) => {
+    const base = this.baseUrl(account, workspace)
+
+    return this.http.get(`${base}/payments/${qs}/request`, {
+      metric: 'payment-request',
+    })
+  }
+
+  public baseUrl = (account: string, workspace: string) => {
+    return `http://${workspace}--${account}.${process.env.VTEX_PUBLIC_ENDPOINT}/affirm/payment-provider`
+  }
 }

--- a/node/resolvers/affirm.ts
+++ b/node/resolvers/affirm.ts
@@ -1,21 +1,37 @@
 export const queries = {
-  affirmSettings: async (_: any, __: any, ctx: Context) => {
+  affirmSettings: async (_: void, __: void, ctx: Context) => {
     const appId = process.env.VTEX_APP_ID as string
     const settings = await ctx.clients.apps.getAppSettings(appId)
     return settings
   },
-  orderData: async (_: any, { qs }: { qs: string }, ctx: Context) => {
+  orderData: async (_: void, { qs }: { qs: string }, ctx: Context) => {
     const {
-      clients: { payments },
+      clients: { licenseManager, payments },
+      vtex: { account, authToken, logger },
     } = ctx
 
-    return payments.getPaymentRequest(qs)
+    // if this is a subaccount, accountName will be the name of the main account
+    const { accountName } = await licenseManager
+      .getAccountData(authToken)
+      .catch(error => {
+        logger.error({
+          message: 'getAccountData-error',
+          error,
+        })
+        return {}
+      })
+
+    return payments.getPaymentRequest(
+      qs,
+      accountName,
+      accountName === account ? undefined : 'master' // if this is a subaccount, send request to master workspace of main account
+    )
   },
 }
 
 export const mutations = {
   orderUpdate: async (
-    _: any,
+    _: void,
     {
       inboundUrl,
       orderId,

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1255,7 +1255,7 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
Problem: if a user is checking out in a subaccount, all payment requests are routed through the main account, but then Affirm Payment (this app, which renders the checkout UI for the user to interact with) is run in the subaccount. So the Affirm connector app (Affirm API) stores the order data in the main account, but then Affirm Payment tries to load the order data in the subaccount (where it doesn't exist). 

This PR allows the Affirm Payment app to recognize that it's running in a subaccount, and when it determines this to be the case, it will load the order data from the main account. 

This new version has been linked in https://arthur--budgetgolfqa.myvtex.com/ and has successfully been used to place a test order: https://budgetgolfqa.myvtex.com/admin/pci-gateway/#/transactions/D963A7A10009401F9475EBBDA6866C82