### PR TITLE
Reduce default delayToCancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Change default `DelayToCancel` app setting value from 60 days to 1 day
+
 ## [2.2.5] - 2022-11-15
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,6 @@ The available settings are:
 - `Delay to automatic payment capture`: Number of minutes/hours/days before authorized Affirm payments are automatically settled.
 - `Delay to automatic payment capture after antifraud analysis`: Number of minutes/hours/days before authorized Affirm payments are automatically settled after merchant's antifraud approval.
 - `Delay to cancel`: Number of minutes/hours/days before Affirm payments are automatically canceled.
-  > ⚠️ _`Delay to cancel` also affects the amount of time the user is given to complete the Affirm checkout modal. As such, the app will enforce a minimum `delay to cancel` time of 60 minutes. Shorter times may be inputted on the settings page, but they will be ignored._
+  > ⚠️ _`Delay to cancel` also affects the amount of time the user is given to complete the Affirm checkout modal. As such, the app will enforce a minimum `delay to cancel` time of 60 minutes. Shorter times may be inputted on the settings page, but they will be ignored. Also, times longer than 1 day should not be used._
 - `Katapult public token`: The public API token for your Katapult account. This is only needed if Katapult is enabled.
 - `Katapult private token`: The private API token for your Katapult account. This is only needed if Katapult is enabled.

--- a/manifest.json
+++ b/manifest.json
@@ -5,9 +5,7 @@
   "title": "Affirm Payment",
   "description": "An implentation of Affirm payment method",
   "categories": [],
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "builders": {
     "react": "2.x",
     "node": "6.x",
@@ -55,11 +53,7 @@
       "delayInterval": {
         "title": "Interval to use for the following three settings",
         "type": "string",
-        "enum": [
-          "Minutes",
-          "Hours",
-          "Days"
-        ],
+        "enum": ["Minutes", "Hours", "Days"],
         "default": "Days"
       },
       "delayToAutoSettle": {
@@ -78,7 +72,7 @@
         "title": "Delay to cancel",
         "description": "Number of minutes/hours/days before Affirm payments are automatically canceled",
         "type": "number",
-        "default": 60
+        "default": 1
       },
       "katapultPublicToken": {
         "title": "Katapult public token (optional)",


### PR DESCRIPTION
Currently the app defaults the `delayToCancel` app setting to 60 days, which is too large. This causes the VTEX payment gateway to retry the authorization every 60 seconds. If the user does not complete the Affirm modal in this 60 second window, their VTEX order is cancelled. 

This PR changes the default `delayToCancel` to 1 day, which results in the authorization being retried every 4 hours. This is the `delayToCancel` already being used by Motorola, so we know it works correctly.

I've also updated the docs to recommend that stores do not use a `delayToCancel` longer than 1 day. 