### PR TITLE
Added feature flag enablePartialCancellation, VTEX key & token to be configure in Vtex Settings of Affirm Payment App

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.0.2] - 2025-03-21
+
 ### Changed
 
 - Update cy-runner.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.0.3] - 2025-03-21
+
 ## [0.0.2] - 2025-03-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Update cy-runner.yml
-- Addedfeature flag enablePartialCancellation, vtex key & token to be configure in Vtex Settings of Affirm Payment App
+- Addedfeature flag enablePartialCancellation in Vtex Settings of Affirm Payment App, which ensures that the amount for partially canceled items is voided during settlement.
 
 ## [2.2.6] - 2022-12-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.0.3] - 2025-03-21
+## [2.2.7] - 2025-03-21
+
+- Addedfeature flag enablePartialCancellation, vtex key & token to be configure in Vtex Settings of Affirm Payment App
 
 ## [0.0.2] - 2025-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.2.7] - 2025-03-21
-
-- Addedfeature flag enablePartialCancellation, vtex key & token to be configure in Vtex Settings of Affirm Payment App
-
-## [0.0.2] - 2025-03-21
-
 ### Changed
 
 - Update cy-runner.yml
+- Addedfeature flag enablePartialCancellation, vtex key & token to be configure in Vtex Settings of Affirm Payment App
 
 ## [2.2.6] - 2022-12-06
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,4 @@ The available settings are:
   > ⚠️ _`Delay to cancel` also affects the amount of time the user is given to complete the Affirm checkout modal. As such, the app will enforce a minimum `delay to cancel` time of 60 minutes. Shorter times may be inputted on the settings page, but they will be ignored. Also, times longer than 1 day should not be used._
 - `Katapult public token`: The public API token for your Katapult account. This is only needed if Katapult is enabled.
 - `Katapult private token`: The private API token for your Katapult account. This is only needed if Katapult is enabled.
-- `Partial cancellation`: Feature flag to enable partial cancellation feature which voids the amount of partially cancelled items on transaction.
-- `VTEX app Key`: The API key used for authenticating requests to the VTEX platform API.
-- `VTEX app Token`: The API token used for authenticating requests to the VTEX platform API.
+- `Partial cancellation`: Feature flag to enable partial cancellation feature, which when enabled, ensures that the amount for partially canceled items on order is voided during settlement.

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,3 +25,6 @@ The available settings are:
   > ⚠️ _`Delay to cancel` also affects the amount of time the user is given to complete the Affirm checkout modal. As such, the app will enforce a minimum `delay to cancel` time of 60 minutes. Shorter times may be inputted on the settings page, but they will be ignored. Also, times longer than 1 day should not be used._
 - `Katapult public token`: The public API token for your Katapult account. This is only needed if Katapult is enabled.
 - `Katapult private token`: The private API token for your Katapult account. This is only needed if Katapult is enabled.
+- `Partial cancellation`: Feature flag to enable partial cancellation feature which voids the amount of partially cancelled items on transaction.
+- `VTEX app Key`: The API key used for authenticating requests to the VTEX platform API.
+- `VTEX app Token`: The API token used for authenticating requests to the VTEX platform API.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "affirm-payment",
   "vendor": "logixalpartnerus",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "title": "Affirm Payment",
   "description": "An implentation of Affirm payment method By Logixal",
   "categories": [],

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "affirm-payment",
   "vendor": "logixalpartnerus",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "title": "Affirm Payment",
   "description": "An implentation of Affirm payment method By Logixal",
   "categories": [],

--- a/manifest.json
+++ b/manifest.json
@@ -97,19 +97,6 @@
         "description": "Enable partial cancellation",
         "type": "boolean",
         "default": false
-      },
-      "vtexAppKey": {
-        "title": "VTEX app key",
-        "description": "The app key for your VTEX account",
-        "type": "string",
-        "default": ""
-      },
-      "vtexAppToken": {
-        "title": "VTEX app token",
-        "description": "The app token for your VTEX account",
-        "type": "string",
-        "format": "password",
-        "default": ""
       }
     }
   },

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "name": "affirm-payment",
-  "vendor": "vtex",
-  "version": "2.2.6",
+  "vendor": "logixalpartnerus",
+  "version": "0.0.1",
   "title": "Affirm Payment",
-  "description": "An implentation of Affirm payment method",
+  "description": "An implentation of Affirm payment method By Logixal",
   "categories": [],
   "registries": [
     "smartcheckout"
@@ -22,7 +22,7 @@
   "dependencies": {
     "vtex.store": "2.x",
     "vtex.styleguide": "9.x",
-    "vtex.affirm-api": "1.x"
+    "logixalpartnerus.affirm-api": "1.x"
   },
   "settingsSchema": {
     "title": "Affirm Integration",

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "vtex.store": "2.x",
     "vtex.styleguide": "9.x",
-    "logixalpartnerus.affirm-api": "1.x"
+    "vtex.affirm-api": "1.x"
   },
   "settingsSchema": {
     "title": "Affirm Integration",

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "name": "affirm-payment",
-  "vendor": "logixalpartnerus",
-  "version": "0.0.3",
+  "vendor": "vtex",
+  "version": "2.2.6",
   "title": "Affirm Payment",
-  "description": "An implentation of Affirm payment method By Logixal",
+  "description": "An implentation of Affirm payment method",
   "categories": [],
   "registries": [
     "smartcheckout"

--- a/manifest.json
+++ b/manifest.json
@@ -91,6 +91,25 @@
         "description": "The private API token for your Katapult account",
         "type": "string",
         "default": ""
+      },
+      "enablePartialCancellation": {
+        "title": "Partial cancellation",
+        "description": "Enable partial cancellation",
+        "type": "boolean",
+        "default": false
+      },
+      "vtexAppKey": {
+        "title": "VTEX app key",
+        "description": "The app key for your VTEX account",
+        "type": "string",
+        "default": ""
+      },
+      "vtexAppToken": {
+        "title": "VTEX app token",
+        "description": "The app token for your VTEX account",
+        "type": "string",
+        "format": "password",
+        "default": ""
       }
     }
   },

--- a/react/graphql/OrderData.graphql
+++ b/react/graphql/OrderData.graphql
@@ -1,5 +1,5 @@
 query OrderData ($qs: String) {
-  orderData(qs: $qs) @context(provider: "logixalpartnerus.affirm-payment") {
+  orderData(qs: $qs) @context(provider: "vtex.affirm-payment") {
     transactionId
     orderId
     miniCart {

--- a/react/graphql/OrderData.graphql
+++ b/react/graphql/OrderData.graphql
@@ -1,5 +1,5 @@
 query OrderData ($qs: String) {
-  orderData(qs: $qs) @context(provider: "vtex.affirm-payment") {
+  orderData(qs: $qs) @context(provider: "logixalpartnerus.affirm-payment") {
     transactionId
     orderId
     miniCart {


### PR DESCRIPTION
Added feature flag enablePartialCancellation, vtex key & token to be configure in Vtex Settings of Affirm Payment App
Changes are added in manifest.json

Configuring the Affirm Partial Cancellation feature:

•	Open the Admin app : https://{VTEX Account}.myvtex.com/admin

•	Go to My App

•	Open Affirm Payment app

•	Configure the partial cancellation feature using the flag: Partial Cancellation

•	Configure the VTEX Account APP Key and Token for the VTEX API.

![image](https://github.com/user-attachments/assets/e64e6988-9f5f-45bc-a78a-c93be943b903)
